### PR TITLE
Read and store Bambu X1 Carbon serial number

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,3 +31,9 @@ Note: you may need to allow user permissions to USB devices. Alternatively, you 
 ## machine-api CLI
 
 You can also use machine-api as a CLI. `cargo run` with no parameters will give the available options.
+
+## Regenerating the OpenAPI definition file
+
+```bash
+EXPECTORATE=overwrite cargo test --all openapi
+```

--- a/openapi/api.json
+++ b/openapi/api.json
@@ -99,6 +99,11 @@
                 "nullable": true,
                 "type": "integer"
               },
+              "serial": {
+                "description": "The serial number of the printer.",
+                "nullable": true,
+                "type": "string"
+              },
               "type": {
                 "enum": [
                   "NetworkPrinter"

--- a/src/network_printer/bambu_x1_carbon.rs
+++ b/src/network_printer/bambu_x1_carbon.rs
@@ -65,6 +65,7 @@ impl NetworkPrinter for BambuX1Carbon {
             let mut urn = None;
             let mut name = None;
             let mut ip = None;
+            let mut serial = None;
             // TODO: This is probably the secure MQTT port 8883 but we need to test that assumption
             #[allow(unused_mut)]
             let mut port = None;
@@ -90,6 +91,7 @@ impl NetworkPrinter for BambuX1Carbon {
                 match token {
                     "Location" => ip = Some(rest.parse().expect("Bad IP")),
                     "DevName.bambu.com" => name = Some(rest.to_owned()),
+                    "USN" => serial = Some(rest.to_owned()),
                     "NT" => urn = Some(rest.to_owned()),
                     // Ignore everything else
                     _ => (),
@@ -124,10 +126,13 @@ impl NetworkPrinter for BambuX1Carbon {
                 // We can hard code this for now as we check the URN above (and assume the URN is
                 // unique to the X1 carbon)
                 model: Some(String::from("Bambu Lab X1 Carbon")),
+                serial,
             };
 
             if self.printers.insert(info.clone()) {
                 tracing::info!("Found printer {:?} at IP {:?}", info.hostname, info.ip);
+
+                tracing::debug!("--> Full printer details {:?}", info);
             }
         }
 

--- a/src/network_printer/formlabs.rs
+++ b/src/network_printer/formlabs.rs
@@ -38,6 +38,7 @@ impl NetworkPrinter for Formlabs {
                     port: response.port(),
                     manufacturer: NetworkPrinterManufacturer::Formlabs,
                     model: None,
+                    serial: None,
                 };
                 self.printers.insert(addr.to_string(), printer);
             } else {

--- a/src/network_printer/mod.rs
+++ b/src/network_printer/mod.rs
@@ -37,6 +37,8 @@ pub struct NetworkPrinterInfo {
     pub manufacturer: NetworkPrinterManufacturer,
     /// The model of the printer.
     pub model: Option<String>,
+    /// The serial number of the printer.
+    pub serial: Option<String>,
 }
 
 /// Network printer manufacturer.


### PR DESCRIPTION
We need the Bambu serial number to connect to it over MQTT when the time comes to do that.

I don't have a Form Labs to test against, so this field is always `None` for those printers in this PR.