### PR TITLE
Refactor GcodeSequence handling and improve error messages

### DIFF
--- a/src/gcode.rs
+++ b/src/gcode.rs
@@ -3,6 +3,7 @@ use std::{
     process::Command,
     sync::Arc,
 };
+use anyhow::Context;
 
 // Use Arc for shared ownership.
 #[derive(Clone)]

--- a/src/gcode.rs
+++ b/src/gcode.rs
@@ -1,29 +1,29 @@
 use std::{
     path::{Path, PathBuf},
     process::Command,
+    sync::Arc,
 };
 
-// TODO don't clone this, maybe use Arc instead.
+// Use Arc for shared ownership.
 #[derive(Clone)]
 pub struct GcodeSequence {
-    pub lines: Vec<String>,
+    pub lines: Arc<Vec<String>>,
 }
 
 impl GcodeSequence {
     pub fn from_file_path(path: &Path) -> anyhow::Result<Self> {
-        Ok(Self {
-            lines: std::fs::read_to_string(path)?
-                .lines() // split the string into an iterator of string slices
-                .map(|s| {
-                    let s = String::from(s);
-                    match s.split_once(';') {
-                        Some((command, _)) => command.trim().to_string(),
-                        None => s.trim().to_string(),
-                    }
-                })
-                .filter(|s| !s.is_empty()) // make each slice into a string
-                .collect(),
-        })
+        let lines = std::fs::read_to_string(path)?
+            .lines() // split the string into an iterator of string slices
+            .map(|s| {
+                let s = String::from(s);
+                match s.split_once(';') {
+                    Some((command, _)) => command.trim().to_string(),
+                    None => s.trim().to_string(),
+                }
+            })
+            .filter(|s| !s.is_empty()) // make each slice into a string
+            .collect();
+        Ok(Self { lines: Arc::new(lines) })
     }
 
     pub fn from_stl_path(slicer_config_path: &Path, stl_path: &Path) -> anyhow::Result<Self> {
@@ -34,18 +34,22 @@ impl GcodeSequence {
 
 fn slice_stl_with_prusa_slicer(config_path: &Path, stl_path: &Path) -> anyhow::Result<PathBuf> {
     let gcode_path = stl_path.with_extension("gcode");
-    let stl = std::fs::read_to_string(stl_path)?;
-    println!("{}", stl);
-    let args: Vec<&str> = vec![
-        "--load",
-        config_path.to_str().ok_or(anyhow::anyhow!("bad slicer config path"))?,
-        "--support-material",
-        "--export-gcode",
-        stl_path.to_str().ok_or(anyhow::anyhow!("bad stl path"))?,
-        "--output",
-        gcode_path.to_str().ok_or(anyhow::anyhow!("bad gcode path"))?,
+
+    let args: Vec<String> = vec![
+        "--load".to_string(),
+        config_path.to_str().ok_or_else(|| anyhow::anyhow!("Invalid slicer config path"))?.to_string(),
+        "--support-material".to_string(),
+        "--export-gcode".to_string(),
+        stl_path.to_str().ok_or_else(|| anyhow::anyhow!("Invalid STL path"))?.to_string(),
+        "--output".to_string(),
+        gcode_path.to_str().ok_or_else(|| anyhow::anyhow!("Invalid G-code path"))?.to_string(),
     ];
-    let output = Command::new("prusa-slicer").args(args).output()?;
+
+    let output = Command::new("prusa-slicer")
+        .args(&args)
+        .output()
+        .context("Failed to execute prusa-slicer command")?;
+
     println!("STDOUT: {}", std::str::from_utf8(&output.stdout)?);
     println!("STDERR: {}", std::str::from_utf8(&output.stderr)?);
 


### PR DESCRIPTION
- Use Arc for GcodeSequence: Allows shared ownership without the need to clone the entire Vec<String>.
- Simplified Command Argument Handling: Converted arguments to String to match the types required by the Command::new method.
- Removed Unused STL Read: Removed unnecessary reading of the STL file content.
- Enhanced Error Messages: Added more context to error messages for easier debugging.