### PR TITLE
Fix incorrect Windows path for OrcaSlicer executable

### DIFF
--- a/src/slicer/orca.rs
+++ b/src/slicer/orca.rs
@@ -107,7 +107,7 @@ fn find_orca_slicer() -> anyhow::Result<PathBuf> {
 // Find the orcaslicer executable path on Windows.
 #[cfg(target_os = "windows")]
 fn find_orca_slicer() -> anyhow::Result<PathBuf> {
-    let app_path = std::path::PathBuf::from("C:\\Program Files\\OrcaSlicer\\OrcaSlicer.exe");
+    let app_path = std::path::PathBuf::from("C:\\Program Files\\OrcaSlicer\\orca-slicer.exe");
     if app_path.exists() {
         Ok(app_path)
     } else {


### PR DESCRIPTION
## Description
This PR fixes the issue with the incorrect Windows path for the OrcaSlicer executable. The original path was `C:\\Program Files\\OrcaSlicer\\OrcaSlicer.exe`, but it should be `C:\\Program Files\\OrcaSlicer\\orca-slicer.exe`. 

Closes: #59 

## Changes Made

- Updated the path to the OrcaSlicer executable to `C:\\Program Files\\OrcaSlicer\\orca-slicer.exe` for Windows.