### PR TITLE
Refactor Signal Handling to be Cross-Platform

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1806,7 +1806,6 @@ dependencies = [
  "serde",
  "serde_json",
  "serialport",
- "signal-hook",
  "slog",
  "slog-async",
  "slog-json",
@@ -3066,16 +3065,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f40ca3c46823713e0d4209592e8d6e826aa57e928f09752619fc696c499637f6"
 dependencies = [
  "lazy_static",
-]
-
-[[package]]
-name = "signal-hook"
-version = "0.3.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8621587d4798caf8eb44879d42e56b9a93ea5dcd315a6487c357130095b62801"
-dependencies = [
- "libc",
- "signal-hook-registry",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,6 @@ schemars = { version = "0.8", features = ["chrono", "uuid1", "bigdecimal"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 serialport = "4.5.0"
-signal-hook = "0.3"
 slog = "2.7.0"
 slog-async = "2.7.0"
 slog-json = "2.6.1"

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5,7 +5,6 @@ use std::{env, net::SocketAddr, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use dropshot::{ApiDescription, ConfigDropshot, HttpServerStarter};
-use tokio::signal;
 
 use crate::{config::Config, network_printer::NetworkPrinterManufacturer, server::context::Context};
 
@@ -35,7 +34,7 @@ async fn handle_signals(api_context: Arc<Context>) -> Result<()> {
 
     #[cfg(windows)]
     {
-        signal::ctrl_c().await.map_err(|e| {
+        tokio::signal::ctrl_c().await.map_err(|e| {
             slog::error!(api_context.logger, "Failed to set up Ctrl+C handler: {:?}", e);
             anyhow::Error::new(e)
         })?;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -5,12 +5,48 @@ use std::{env, net::SocketAddr, sync::Arc};
 
 use anyhow::{anyhow, Result};
 use dropshot::{ApiDescription, ConfigDropshot, HttpServerStarter};
-use signal_hook::{
-    consts::{SIGINT, SIGTERM},
-    iterator::Signals,
-};
+use tokio::signal;
 
 use crate::{config::Config, network_printer::NetworkPrinterManufacturer, server::context::Context};
+
+async fn handle_signals(api_context: Arc<Context>) -> Result<()> {
+    #[cfg(unix)]
+    {
+        use tokio::signal::unix::{signal, SignalKind};
+
+        let mut sigint = signal(SignalKind::interrupt()).map_err(|e| {
+            slog::error!(api_context.logger, "Failed to set up SIGINT handler: {:?}", e);
+            e
+        })?;
+        let mut sigterm = signal(SignalKind::terminate()).map_err(|e| {
+            slog::error!(api_context.logger, "Failed to set up SIGTERM handler: {:?}", e);
+            e
+        })?;
+
+        tokio::select! {
+            _ = sigint.recv() => {
+                slog::info!(api_context.logger, "received SIGINT");
+            }
+            _ = sigterm.recv() => {
+                slog::info!(api_context.logger, "received SIGTERM");
+            }
+        }
+    }
+
+    #[cfg(windows)]
+    {
+        signal::ctrl_c().await.map_err(|e| {
+            slog::error!(api_context.logger, "Failed to set up Ctrl+C handler: {:?}", e);
+            anyhow::Error::new(e)
+        })?;
+
+        slog::info!(api_context.logger, "received Ctrl+C (SIGINT)");
+    }
+
+    slog::info!(api_context.logger, "triggering cleanup...");
+    slog::info!(api_context.logger, "all clean, exiting!");
+    std::process::exit(0);
+}
 
 /// Create an API description for the server.
 pub fn create_api_description() -> Result<ApiDescription<Arc<Context>>> {
@@ -90,20 +126,9 @@ pub async fn server(s: &crate::Server, opts: &crate::Opts, config: &Config) -> R
     // For Cloud run & ctrl+c, shutdown gracefully.
     // "The main process inside the container will receive SIGTERM, and after a grace period,
     // SIGKILL."
-    // Regsitering SIGKILL here will panic at runtime, so let's avoid that.
-    let mut signals = Signals::new([SIGINT, SIGTERM])?;
-
+    // Registering SIGKILL here will panic at runtime, so let's avoid that.
     let cloned_api_context = api_context.clone();
-    tokio::spawn(async move {
-        if let Some(sig) = signals.forever().next() {
-            slog::info!(cloned_api_context.logger, "received signal: {:?}", sig);
-            slog::info!(cloned_api_context.logger, "triggering cleanup...");
-
-            // Exit the process.
-            slog::info!(cloned_api_context.logger, "all clean, exiting!");
-            std::process::exit(0);
-        }
-    });
+    tokio::spawn(handle_signals(cloned_api_context));
 
     // Start all the discovery tasks.
     tokio::spawn(async move {


### PR DESCRIPTION
This PR introduces the proposed changes from #58 

- Removed the dependency on signal_hook.
- Implemented Unix-specific signal handling using tokio::signal::unix.
- Implemented Windows-specific signal handling using tokio::signal::ctrl_c.

