### PR TITLE
Add in MachineState to the Control trait, HTTP Endpoint

### DIFF
--- a/moonraker/src/lib.rs
+++ b/moonraker/src/lib.rs
@@ -12,6 +12,7 @@
 
 mod metrics;
 mod print;
+mod status;
 mod upload;
 
 use anyhow::Result;

--- a/moonraker/src/status.rs
+++ b/moonraker/src/status.rs
@@ -1,0 +1,67 @@
+use anyhow::Result;
+use serde::{Deserialize, Serialize};
+
+use super::Client;
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct VirtualSdcard {
+    pub progress: f64,
+    pub file_position: usize,
+    pub is_active: bool,
+    pub file_path: String,
+    pub file_size: usize,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct Webhooks {
+    pub state: String,
+    pub state_message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct PrintStats {
+    pub print_duration: f64,
+    pub total_duration: f64,
+    pub filament_used: f64,
+    pub filename: String,
+    pub state: String,
+    pub message: String,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+pub struct Status {
+    pub virtual_sdcard: VirtualSdcard,
+    pub webhooks: Webhooks,
+    pub print_stats: PrintStats,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+struct QueryResponse {
+    status: Status,
+    eventtime: f64,
+}
+
+#[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
+struct QueryResponseWrapper {
+    result: QueryResponse,
+}
+
+impl Client {
+    /// Print an uploaded file.
+    pub async fn status(&self) -> Result<Status> {
+        tracing::debug!(base = self.url_base, "requesting status");
+        let client = reqwest::Client::new();
+
+        let resp: QueryResponseWrapper = client
+            .get(format!(
+                "{}/printer/objects/query?webhooks&virtual_sdcard&print_stats",
+                self.url_base
+            ))
+            .send()
+            .await?
+            .json()
+            .await?;
+
+        Ok(resp.result.status)
+    }
+}

--- a/moonraker/src/status.rs
+++ b/moonraker/src/status.rs
@@ -6,10 +6,10 @@ use super::Client;
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]
 pub struct VirtualSdcard {
     pub progress: f64,
-    pub file_position: usize,
+    pub file_position: f64,
     pub is_active: bool,
-    pub file_path: String,
-    pub file_size: usize,
+    pub file_path: Option<String>,
+    pub file_size: f64,
 }
 
 #[derive(Clone, Debug, PartialEq, Deserialize, Serialize)]

--- a/openapi/api.json
+++ b/openapi/api.json
@@ -114,10 +114,10 @@
             "description": "Maximum part size that can be manufactured by this device. This may be some sort of theoretical upper bound, getting close to this limit seems like maybe a bad idea.\n\nThis may be `None` if the maximum size is not knowable by the Machine API.\n\nWhat \"close\" means is up to you!",
             "nullable": true
           },
-          "print_state": {
+          "state": {
             "allOf": [
               {
-                "$ref": "#/components/schemas/PrintState"
+                "$ref": "#/components/schemas/MachineState"
               }
             ],
             "description": "Status of the printer -- be it printing, idle, or unreachable. This may dictate if a machine is capable of taking a new job."
@@ -127,7 +127,7 @@
           "id",
           "machine_type",
           "make_model",
-          "print_state"
+          "state"
         ],
         "type": "object"
       },
@@ -151,6 +151,67 @@
           }
         },
         "type": "object"
+      },
+      "MachineState": {
+        "description": "Current state of the machine -- be it printing, idle or offline. This can be used to determine if a printer is in the correct state to take a new job.",
+        "oneOf": [
+          {
+            "description": "If a print state can not be resolved at this time, an Unknown may be returned.",
+            "enum": [
+              "Unknown"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Idle, and ready for another job.",
+            "enum": [
+              "Idle"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Running a job -- 3D printing or CNC-ing a part.",
+            "enum": [
+              "Running"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Machine is currently offline or unreachable.",
+            "enum": [
+              "Offline"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Job is underway but halted, waiting for some action to take place.",
+            "enum": [
+              "Paused"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Job is finished, but waiting manual action to move back to Idle.",
+            "enum": [
+              "Complete"
+            ],
+            "type": "string"
+          },
+          {
+            "additionalProperties": false,
+            "description": "The printer has failed and is in an unknown state that may require manual attention to resolve. The inner value is a human readable description of what specifically has failed.",
+            "properties": {
+              "Failed": {
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "Failed"
+            ],
+            "type": "object"
+          }
+        ]
       },
       "MachineType": {
         "description": "Specific technique by which this Machine takes a design, and produces a real-world 3D object.",
@@ -230,67 +291,6 @@
           "machine_id"
         ],
         "type": "object"
-      },
-      "PrintState": {
-        "description": "Current state of the printer -- be it printing, idle or offline. This can be used to determine if a printer is in the correct state to take a new job.",
-        "oneOf": [
-          {
-            "description": "If a print state can not be resolved at this time, an Unknown may be returned.",
-            "enum": [
-              "Unknown"
-            ],
-            "type": "string"
-          },
-          {
-            "description": "Idle, and ready for another job.",
-            "enum": [
-              "Idle"
-            ],
-            "type": "string"
-          },
-          {
-            "description": "Running a job -- 3D printing or CNC-ing a part.",
-            "enum": [
-              "Running"
-            ],
-            "type": "string"
-          },
-          {
-            "description": "Machine is currently offline or unreachable.",
-            "enum": [
-              "Offline"
-            ],
-            "type": "string"
-          },
-          {
-            "description": "Job is underway but halted, waiting for some action to take place.",
-            "enum": [
-              "Paused"
-            ],
-            "type": "string"
-          },
-          {
-            "description": "Job is finished, but waiting manual action to move back to Idle.",
-            "enum": [
-              "Complete"
-            ],
-            "type": "string"
-          },
-          {
-            "additionalProperties": false,
-            "description": "The printer has failed and is in an unknown state that may require manual attention to resolve. The inner value is a human readable description of what specifically has failed.",
-            "properties": {
-              "Failed": {
-                "nullable": true,
-                "type": "string"
-              }
-            },
-            "required": [
-              "Failed"
-            ],
-            "type": "object"
-          }
-        ]
       },
       "Volume": {
         "description": "Set of three values to represent the extent of a 3-D Volume. This contains the width, depth, and height values, generally used to represent some maximum or minimum.\n\nAll measurements are in millimeters.",

--- a/openapi/api.json
+++ b/openapi/api.json
@@ -113,12 +113,21 @@
             ],
             "description": "Maximum part size that can be manufactured by this device. This may be some sort of theoretical upper bound, getting close to this limit seems like maybe a bad idea.\n\nThis may be `None` if the maximum size is not knowable by the Machine API.\n\nWhat \"close\" means is up to you!",
             "nullable": true
+          },
+          "print_state": {
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/PrintState"
+              }
+            ],
+            "description": "Status of the printer -- be it printing, idle, or unreachable. This may dictate if a machine is capable of taking a new job."
           }
         },
         "required": [
           "id",
           "machine_type",
-          "make_model"
+          "make_model",
+          "print_state"
         ],
         "type": "object"
       },
@@ -221,6 +230,67 @@
           "machine_id"
         ],
         "type": "object"
+      },
+      "PrintState": {
+        "description": "Current state of the printer -- be it printing, idle or offline. This can be used to determine if a printer is in the correct state to take a new job.",
+        "oneOf": [
+          {
+            "description": "If a print state can not be resolved at this time, an Unknown may be returned.",
+            "enum": [
+              "Unknown"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Idle, and ready for another job.",
+            "enum": [
+              "Idle"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Running a job -- 3D printing or CNC-ing a part.",
+            "enum": [
+              "Running"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Machine is currently offline or unreachable.",
+            "enum": [
+              "Offline"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Job is underway but halted, waiting for some action to take place.",
+            "enum": [
+              "Paused"
+            ],
+            "type": "string"
+          },
+          {
+            "description": "Job is finished, but waiting manual action to move back to Idle.",
+            "enum": [
+              "Complete"
+            ],
+            "type": "string"
+          },
+          {
+            "additionalProperties": false,
+            "description": "The printer has failed and is in an unknown state that may require manual attention to resolve. The inner value is a human readable description of what specifically has failed.",
+            "properties": {
+              "Failed": {
+                "nullable": true,
+                "type": "string"
+              }
+            },
+            "required": [
+              "Failed"
+            ],
+            "type": "object"
+          }
+        ]
       },
       "Volume": {
         "description": "Set of three values to represent the extent of a 3-D Volume. This contains the width, depth, and height values, generally used to represent some maximum or minimum.\n\nAll measurements are in millimeters.",

--- a/src/any_machine.rs
+++ b/src/any_machine.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use crate::{Control as ControlTrait, MachineInfo, MachineMakeModel, MachineType, PrintState, Volume};
+use crate::{Control as ControlTrait, MachineInfo, MachineMakeModel, MachineState, MachineType, Volume};
 
 /// AnyMachine is any supported machine.
 #[non_exhaustive]
@@ -129,7 +129,7 @@ impl ControlTrait for AnyMachine {
         for_all!(|self, machine| { machine.healthy().await })
     }
 
-    async fn print_state(&self) -> Result<PrintState> {
-        for_all!(|self, machine| { machine.print_state().await })
+    async fn state(&self) -> Result<MachineState> {
+        for_all!(|self, machine| { machine.state().await })
     }
 }

--- a/src/any_machine.rs
+++ b/src/any_machine.rs
@@ -1,6 +1,6 @@
 use anyhow::Result;
 
-use crate::{Control as ControlTrait, MachineInfo, MachineMakeModel, MachineType, Volume};
+use crate::{Control as ControlTrait, MachineInfo, MachineMakeModel, MachineType, PrintState, Volume};
 
 /// AnyMachine is any supported machine.
 #[non_exhaustive]
@@ -127,5 +127,9 @@ impl ControlTrait for AnyMachine {
 
     async fn healthy(&self) -> bool {
         for_all!(|self, machine| { machine.healthy().await })
+    }
+
+    async fn print_state(&self) -> Result<PrintState> {
+        for_all!(|self, machine| { machine.print_state().await })
     }
 }

--- a/src/bambu/control.rs
+++ b/src/bambu/control.rs
@@ -3,7 +3,7 @@ use bambulabs::{client::Client, command::Command};
 
 use super::{PrinterInfo, X1Carbon};
 use crate::{
-    Control as ControlTrait, MachineInfo as MachineInfoTrait, MachineMakeModel, MachineType,
+    Control as ControlTrait, MachineInfo as MachineInfoTrait, MachineMakeModel, MachineType, PrintState,
     SuspendControl as SuspendControlTrait, ThreeMfControl as ThreeMfControlTrait, ThreeMfTemporaryFile, Volume,
 };
 
@@ -73,6 +73,10 @@ impl ControlTrait for X1Carbon {
     async fn healthy(&self) -> bool {
         // TODO: fix this
         true
+    }
+
+    async fn print_state(&self) -> Result<PrintState> {
+        Ok(PrintState::Unknown)
     }
 }
 

--- a/src/bambu/control.rs
+++ b/src/bambu/control.rs
@@ -3,7 +3,7 @@ use bambulabs::{client::Client, command::Command};
 
 use super::{PrinterInfo, X1Carbon};
 use crate::{
-    Control as ControlTrait, MachineInfo as MachineInfoTrait, MachineMakeModel, MachineType, PrintState,
+    Control as ControlTrait, MachineInfo as MachineInfoTrait, MachineMakeModel, MachineState, MachineType,
     SuspendControl as SuspendControlTrait, ThreeMfControl as ThreeMfControlTrait, ThreeMfTemporaryFile, Volume,
 };
 
@@ -75,8 +75,8 @@ impl ControlTrait for X1Carbon {
         true
     }
 
-    async fn print_state(&self) -> Result<PrintState> {
-        Ok(PrintState::Unknown)
+    async fn state(&self) -> Result<MachineState> {
+        Ok(MachineState::Unknown)
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ use serde::{Deserialize, Serialize};
 pub use slicer::AnySlicer;
 pub use sync::SharedMachine;
 pub use traits::{
-    Control, GcodeControl, GcodeSlicer, GcodeTemporaryFile, MachineInfo, MachineMakeModel, MachineType, MachineState,
+    Control, GcodeControl, GcodeSlicer, GcodeTemporaryFile, MachineInfo, MachineMakeModel, MachineState, MachineType,
     SuspendControl, ThreeMfControl, ThreeMfSlicer, ThreeMfTemporaryFile,
 };
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,8 +43,8 @@ use serde::{Deserialize, Serialize};
 pub use slicer::AnySlicer;
 pub use sync::SharedMachine;
 pub use traits::{
-    Control, GcodeControl, GcodeSlicer, GcodeTemporaryFile, MachineInfo, MachineMakeModel, MachineType, SuspendControl,
-    ThreeMfControl, ThreeMfSlicer, ThreeMfTemporaryFile,
+    Control, GcodeControl, GcodeSlicer, GcodeTemporaryFile, MachineInfo, MachineMakeModel, MachineType, PrintState,
+    SuspendControl, ThreeMfControl, ThreeMfSlicer, ThreeMfTemporaryFile,
 };
 
 /// A specific file containing a design to be manufactured.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -43,7 +43,7 @@ use serde::{Deserialize, Serialize};
 pub use slicer::AnySlicer;
 pub use sync::SharedMachine;
 pub use traits::{
-    Control, GcodeControl, GcodeSlicer, GcodeTemporaryFile, MachineInfo, MachineMakeModel, MachineType, PrintState,
+    Control, GcodeControl, GcodeSlicer, GcodeTemporaryFile, MachineInfo, MachineMakeModel, MachineType, MachineState,
     SuspendControl, ThreeMfControl, ThreeMfSlicer, ThreeMfTemporaryFile,
 };
 

--- a/src/moonraker/control.rs
+++ b/src/moonraker/control.rs
@@ -6,7 +6,7 @@ use moonraker::InfoResponse;
 use super::Client;
 use crate::{
     Control as ControlTrait, GcodeControl as GcodeControlTrait, GcodeTemporaryFile, MachineInfo as MachineInfoTrait,
-    MachineMakeModel, MachineType, SuspendControl as SuspendControlTrait, Volume,
+    MachineMakeModel, MachineType, PrintState, SuspendControl as SuspendControlTrait, Volume,
 };
 
 /// Information about the connected Moonraker-based printer.
@@ -63,6 +63,10 @@ impl ControlTrait for Client {
 
     async fn healthy(&self) -> bool {
         self.client.info().await.is_ok()
+    }
+
+    async fn print_state(&self) -> Result<PrintState> {
+        Ok(PrintState::Unknown)
     }
 }
 

--- a/src/moonraker/control.rs
+++ b/src/moonraker/control.rs
@@ -6,7 +6,7 @@ use moonraker::InfoResponse;
 use super::Client;
 use crate::{
     Control as ControlTrait, GcodeControl as GcodeControlTrait, GcodeTemporaryFile, MachineInfo as MachineInfoTrait,
-    MachineMakeModel, MachineType, PrintState, SuspendControl as SuspendControlTrait, Volume,
+    MachineMakeModel, MachineState, MachineType, SuspendControl as SuspendControlTrait, Volume,
 };
 
 /// Information about the connected Moonraker-based printer.
@@ -65,17 +65,17 @@ impl ControlTrait for Client {
         self.client.info().await.is_ok()
     }
 
-    async fn print_state(&self) -> Result<PrintState> {
+    async fn state(&self) -> Result<MachineState> {
         let status = self.client.status().await?;
 
         Ok(match status.print_stats.state.as_str() {
-            "printing" => PrintState::Running,
-            "standby" => PrintState::Idle,
-            "paused" => PrintState::Paused,
-            "complete" => PrintState::Complete,
-            "cancelled" => PrintState::Complete,
-            "error" => PrintState::Failed(Some(status.print_stats.message.to_owned())),
-            _ => PrintState::Unknown,
+            "printing" => MachineState::Running,
+            "standby" => MachineState::Idle,
+            "paused" => MachineState::Paused,
+            "complete" => MachineState::Complete,
+            "cancelled" => MachineState::Complete,
+            "error" => MachineState::Failed(Some(status.print_stats.message.to_owned())),
+            _ => MachineState::Unknown,
         })
     }
 }

--- a/src/moonraker/control.rs
+++ b/src/moonraker/control.rs
@@ -66,7 +66,17 @@ impl ControlTrait for Client {
     }
 
     async fn print_state(&self) -> Result<PrintState> {
-        Ok(PrintState::Unknown)
+        let status = self.client.status().await?;
+
+        Ok(match status.print_stats.state.as_str() {
+            "printing" => PrintState::Running,
+            "standby" => PrintState::Idle,
+            "paused" => PrintState::Paused,
+            "complete" => PrintState::Complete,
+            "cancelled" => PrintState::Complete,
+            "error" => PrintState::Failed(Some(status.print_stats.message.to_owned())),
+            _ => PrintState::Unknown,
+        })
     }
 }
 

--- a/src/noop.rs
+++ b/src/noop.rs
@@ -5,7 +5,7 @@ use anyhow::Result;
 
 use crate::{
     Control as ControlTrait, GcodeControl as GcodeControlTrait, GcodeTemporaryFile, MachineInfo as MachineInfoTrait,
-    MachineMakeModel, MachineType, PrintState, SuspendControl as SuspendControlTrait,
+    MachineMakeModel, MachineState, MachineType, SuspendControl as SuspendControlTrait,
     ThreeMfControl as ThreeMfControlTrait, ThreeMfTemporaryFile, Volume,
 };
 
@@ -71,8 +71,8 @@ impl ControlTrait for Noop {
         true
     }
 
-    async fn print_state(&self) -> Result<PrintState> {
-        Ok(PrintState::Unknown)
+    async fn state(&self) -> Result<MachineState> {
+        Ok(MachineState::Unknown)
     }
 }
 

--- a/src/noop.rs
+++ b/src/noop.rs
@@ -5,8 +5,8 @@ use anyhow::Result;
 
 use crate::{
     Control as ControlTrait, GcodeControl as GcodeControlTrait, GcodeTemporaryFile, MachineInfo as MachineInfoTrait,
-    MachineMakeModel, MachineType, SuspendControl as SuspendControlTrait, ThreeMfControl as ThreeMfControlTrait,
-    ThreeMfTemporaryFile, Volume,
+    MachineMakeModel, MachineType, PrintState, SuspendControl as SuspendControlTrait,
+    ThreeMfControl as ThreeMfControlTrait, ThreeMfTemporaryFile, Volume,
 };
 
 /// Noop-machine will no-op, well, everything.
@@ -69,6 +69,10 @@ impl ControlTrait for Noop {
 
     async fn healthy(&self) -> bool {
         true
+    }
+
+    async fn print_state(&self) -> Result<PrintState> {
+        Ok(PrintState::Unknown)
     }
 }
 

--- a/src/server/endpoints.rs
+++ b/src/server/endpoints.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{Context, CorsResponseOk};
 use crate::{
-    AnyMachine, Control, DesignFile, MachineInfo, MachineMakeModel, MachineType, PrintState, TemporaryFile, Volume,
+    AnyMachine, Control, DesignFile, MachineInfo, MachineMakeModel, MachineType, MachineState, TemporaryFile, Volume,
 };
 
 /// Return the OpenAPI schema in JSON format.
@@ -72,7 +72,7 @@ pub struct MachineInfoResponse {
 
     /// Status of the printer -- be it printing, idle, or unreachable. This
     /// may dictate if a machine is capable of taking a new job.
-    pub print_state: PrintState,
+    pub state: MachineState,
 
     /// Additional, per-machine information which is specific to the
     /// underlying machine type.
@@ -89,7 +89,7 @@ impl MachineInfoResponse {
             make_model: machine_info.make_model(),
             machine_type: machine_info.machine_type(),
             max_part_volume: machine_info.max_part_volume(),
-            print_state: machine.print_state().await?,
+            state: machine.state().await?,
             extra: match machine {
                 AnyMachine::Moonraker(_) => Some(ExtraMachineInfoResponse::Moonraker {}),
                 AnyMachine::Usb(_) => Some(ExtraMachineInfoResponse::Usb {}),

--- a/src/server/endpoints.rs
+++ b/src/server/endpoints.rs
@@ -6,7 +6,7 @@ use serde::{Deserialize, Serialize};
 
 use super::{Context, CorsResponseOk};
 use crate::{
-    AnyMachine, Control, DesignFile, MachineInfo, MachineMakeModel, MachineType, MachineState, TemporaryFile, Volume,
+    AnyMachine, Control, DesignFile, MachineInfo, MachineMakeModel, MachineState, MachineType, TemporaryFile, Volume,
 };
 
 /// Return the OpenAPI schema in JSON format.

--- a/src/server/endpoints.rs
+++ b/src/server/endpoints.rs
@@ -5,7 +5,9 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::{Context, CorsResponseOk};
-use crate::{AnyMachine, Control, DesignFile, MachineInfo, MachineMakeModel, MachineType, TemporaryFile, Volume};
+use crate::{
+    AnyMachine, Control, DesignFile, MachineInfo, MachineMakeModel, MachineType, PrintState, TemporaryFile, Volume,
+};
 
 /// Return the OpenAPI schema in JSON format.
 #[endpoint {
@@ -68,6 +70,10 @@ pub struct MachineInfoResponse {
     /// What "close" means is up to you!
     pub max_part_volume: Option<Volume>,
 
+    /// Status of the printer -- be it printing, idle, or unreachable. This
+    /// may dictate if a machine is capable of taking a new job.
+    pub print_state: PrintState,
+
     /// Additional, per-machine information which is specific to the
     /// underlying machine type.
     pub extra: Option<ExtraMachineInfoResponse>,
@@ -83,6 +89,7 @@ impl MachineInfoResponse {
             make_model: machine_info.make_model(),
             machine_type: machine_info.machine_type(),
             max_part_volume: machine_info.max_part_volume(),
+            print_state: machine.print_state().await?,
             extra: match machine {
                 AnyMachine::Moonraker(_) => Some(ExtraMachineInfoResponse::Moonraker {}),
                 AnyMachine::Usb(_) => Some(ExtraMachineInfoResponse::Usb {}),

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,4 +1,4 @@
-use crate::{Control, PrintState};
+use crate::{Control, MachineState};
 use std::sync::Arc;
 use tokio::sync::Mutex;
 
@@ -40,7 +40,7 @@ where
     async fn healthy(&self) -> bool {
         self.0.lock().await.healthy().await
     }
-    async fn print_state(&self) -> Result<PrintState, Self::Error> {
-        self.0.lock().await.print_state().await
+    async fn state(&self) -> Result<MachineState, Self::Error> {
+        self.0.lock().await.state().await
     }
 }

--- a/src/sync.rs
+++ b/src/sync.rs
@@ -1,8 +1,6 @@
+use crate::{Control, PrintState};
 use std::sync::Arc;
-
 use tokio::sync::Mutex;
-
-use crate::Control;
 
 /// Wrapper around an `Arc<Mutex<Control>>`, which helpfully will handle
 /// the locking to expose a [Control] without the caller having to care
@@ -41,5 +39,8 @@ where
     }
     async fn healthy(&self) -> bool {
         self.0.lock().await.healthy().await
+    }
+    async fn print_state(&self) -> Result<PrintState, Self::Error> {
+        self.0.lock().await.print_state().await
     }
 }

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -50,6 +50,30 @@ pub trait MachineInfo {
     fn max_part_volume(&self) -> Option<Volume>;
 }
 
+/// Current state of the printer -- be it printing, idle or offline. This can
+/// be used to determine if a printer is in the correct state to take a new
+/// job.
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
+pub enum PrintState {
+    /// If a print state can not be resolved at this time, an Unknown may
+    /// be returned.
+    Unknown,
+
+    /// Idle, and ready for another job.
+    Idle,
+
+    /// Running a job -- 3D printing or CNC-ing a part.
+    Running,
+
+    /// Machine is currently offline or unreachable.
+    Offline,
+
+    /// The printer has failed and is in an unknown state that may require
+    /// manual attention to resolve. The inner value is a human
+    /// readable description of what specifically has failed.
+    Failed(Option<String>),
+}
+
 /// A `Machine` is something that can take a 3D model (in one of the
 /// supported formats), and create a physical, real-world copy of
 /// that model.
@@ -87,6 +111,9 @@ pub trait Control {
     /// `false` means the machine is no longer reachable or usable, and
     /// ought to be removed.
     fn healthy(&self) -> impl Future<Output = bool>;
+
+    /// Return the state of the printer.
+    fn print_state(&self) -> impl Future<Output = Result<PrintState, Self::Error>>;
 }
 
 /// [ControlGcode] is used by Machines that accept gcode, control commands

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -68,6 +68,12 @@ pub enum PrintState {
     /// Machine is currently offline or unreachable.
     Offline,
 
+    /// Job is underway but halted, waiting for some action to take place.
+    Paused,
+
+    /// Job is finished, but waiting manual action to move back to Idle.
+    Complete,
+
     /// The printer has failed and is in an unknown state that may require
     /// manual attention to resolve. The inner value is a human
     /// readable description of what specifically has failed.

--- a/src/traits.rs
+++ b/src/traits.rs
@@ -50,11 +50,11 @@ pub trait MachineInfo {
     fn max_part_volume(&self) -> Option<Volume>;
 }
 
-/// Current state of the printer -- be it printing, idle or offline. This can
+/// Current state of the machine -- be it printing, idle or offline. This can
 /// be used to determine if a printer is in the correct state to take a new
 /// job.
 #[derive(Debug, Clone, PartialEq, Serialize, Deserialize, JsonSchema)]
-pub enum PrintState {
+pub enum MachineState {
     /// If a print state can not be resolved at this time, an Unknown may
     /// be returned.
     Unknown,
@@ -119,7 +119,7 @@ pub trait Control {
     fn healthy(&self) -> impl Future<Output = bool>;
 
     /// Return the state of the printer.
-    fn print_state(&self) -> impl Future<Output = Result<PrintState, Self::Error>>;
+    fn state(&self) -> impl Future<Output = Result<MachineState, Self::Error>>;
 }
 
 /// [ControlGcode] is used by Machines that accept gcode, control commands

--- a/src/usb/control.rs
+++ b/src/usb/control.rs
@@ -9,7 +9,7 @@ use tokio_serial::SerialStream;
 
 use crate::{
     gcode::Client, Control as ControlTrait, GcodeControl as GcodeControlTrait, GcodeTemporaryFile,
-    MachineInfo as MachineInfoTrait, MachineMakeModel, MachineType, Volume,
+    MachineInfo as MachineInfoTrait, MachineMakeModel, MachineType, PrintState, Volume,
 };
 
 /// Handle to a USB based gcode 3D printer.
@@ -130,6 +130,10 @@ impl ControlTrait for Usb {
 
     async fn stop(&mut self) -> Result<()> {
         self.client.lock().await.stop().await
+    }
+
+    async fn print_state(&self) -> Result<PrintState> {
+        Ok(PrintState::Unknown)
     }
 
     async fn healthy(&self) -> bool {

--- a/src/usb/control.rs
+++ b/src/usb/control.rs
@@ -9,7 +9,7 @@ use tokio_serial::SerialStream;
 
 use crate::{
     gcode::Client, Control as ControlTrait, GcodeControl as GcodeControlTrait, GcodeTemporaryFile,
-    MachineInfo as MachineInfoTrait, MachineMakeModel, MachineType, PrintState, Volume,
+    MachineInfo as MachineInfoTrait, MachineMakeModel, MachineState, MachineType, Volume,
 };
 
 /// Handle to a USB based gcode 3D printer.
@@ -132,8 +132,8 @@ impl ControlTrait for Usb {
         self.client.lock().await.stop().await
     }
 
-    async fn print_state(&self) -> Result<PrintState> {
-        Ok(PrintState::Unknown)
+    async fn state(&self) -> Result<MachineState> {
+        Ok(MachineState::Unknown)
     }
 
     async fn healthy(&self) -> bool {


### PR DESCRIPTION
This is a first step as we start to chip away on #68 slash #49 and others.

This will add a standard part of our "Control" trait to check on the state of a printer -- is the printer running? idle? paused mid-print? Broken?

I implemented this for Moonraker (since I was able to test it), and stubbed in Unknown elsewhere. USB is doable here -- and I think we can do Bambu, but that may wait until I get into the office to play with it myself.