### PR TITLE
fix otel crate api breakage

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -84,7 +84,7 @@ pub async fn create_server(
 /// Get the OpenAPI specification for the server.
 pub fn get_openapi(api: &mut ApiDescription<Arc<Context>>) -> Result<serde_json::Value> {
     // Create the API schema.
-    let mut definition = api.openapi("machine-api", clap::crate_version!());
+    let mut definition = api.openapi("machine-api", clap::crate_version!().parse()?);
     definition
         .description("")
         .contact_url("https://zoo.dev")


### PR DESCRIPTION
I'm not convinced the otel stuff is right, the API here changed a ton between 0.26 and 0.27. I'm going to read more carefully but this was what I could infer off READMEs.

There's no upgrading guide.