### PR TITLE
Fix up some things that have changed with Prusa Slicer

### DIFF
--- a/flake.nix
+++ b/flake.nix
@@ -64,6 +64,7 @@
           ]) ++ pkgs.lib.optionals pkgs.stdenv.isDarwin (with pkgs; [
             libiconv 
             darwin.apple_sdk.frameworks.Security
+            darwin.apple_sdk.frameworks.SystemConfiguration
           ]);
 
           LD_LIBRARY_PATH = "${pkgs.stdenv.cc.cc.lib}/lib";

--- a/src/slicer/prusa.rs
+++ b/src/slicer/prusa.rs
@@ -129,7 +129,7 @@ impl ThreeMfSlicerTrait for Slicer {
 // Find the prusaslicer executable path on macOS.
 #[cfg(target_os = "macos")]
 fn find_prusa_slicer() -> Result<PathBuf> {
-    let app_path = PathBuf::from("/Applications/PrusaSlicer.app/Contents/MacOS/PrusaSlicer");
+    let app_path = PathBuf::from("/Applications/Original Prusa Drivers/PrusaSlicer.app/Contents/MacOS/PrusaSlicer");
     if app_path.exists() {
         Ok(app_path)
     } else {

--- a/src/usb/control.rs
+++ b/src/usb/control.rs
@@ -137,7 +137,7 @@ impl ControlTrait for Usb {
     }
 
     async fn state(&self) -> Result<MachineState> {
-        Ok(MachineState::Unknown)
+        Ok(MachineState::Idle)
     }
 
     async fn progress(&self) -> Result<Option<f64>> {


### PR DESCRIPTION
Just found these small issues when running again locally today. One is just a change related to where Prusa installs on macos. The other is to just always assume Usb printers are idle until we can better handle print state.