### PR TITLE
Remove `lazy_static!` for `ATOMIC_COUNTER`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -211,7 +211,6 @@ dependencies = [
  "dashmap",
  "format_serde_error",
  "include_dir",
- "lazy_static",
  "nanoid",
  "parse-display",
  "pretty_assertions",

--- a/bambulabs/Cargo.toml
+++ b/bambulabs/Cargo.toml
@@ -8,7 +8,6 @@ anyhow = "1.0.95"
 dashmap = "6.1.0"
 format_serde_error = { version = "0.3.0", default-features = false, features = ["serde_json"] }
 include_dir = { version = "0.7.4", features = ["glob"] }
-lazy_static = "1.5.0"
 nanoid = "0.4.0"
 parse-display = "0.10.0"
 rumqttc = "0.24.0"

--- a/bambulabs/src/sequence_id.rs
+++ b/bambulabs/src/sequence_id.rs
@@ -7,10 +7,8 @@ use parse_display::{Display, FromStr};
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-lazy_static::lazy_static! {
-    /// The atomic counter for sequence IDs.
-    pub static ref ATOMIC_COUNTER: AtomicU32 = AtomicU32::new(0);
-}
+/// The atomic counter for sequence IDs.
+pub static ATOMIC_COUNTER: AtomicU32 = AtomicU32::new(0);
 
 /// The sequence id type.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, Serialize, Deserialize, JsonSchema, Display, FromStr)]


### PR DESCRIPTION
`AtomicU32::new` is a `const fn`, so we don't need lazy initialization. This reduces the number of operations needed to increment the counter.